### PR TITLE
Feat/tests for variance layer

### DIFF
--- a/models/cost_regularizer.py
+++ b/models/cost_regularizer.py
@@ -1,0 +1,193 @@
+# models/cost_regularization.py
+
+#!/usr/bin/env python
+"""
+Copyright 2019, Yao Yao, HKUST.
+Modified for PyTorch implementation.
+MVSNet Cost Volume Regularization Network.
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class ConvBnReLU3D(nn.Module):
+    """Basic Conv3D + BatchNorm3D + ReLU block."""
+    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, pad=1, **kwargs):
+        super(ConvBnReLU3D, self).__init__()
+        self.conv = nn.Conv3d(in_channels, out_channels, kernel_size=kernel_size,
+                              stride=stride, padding=pad, bias=False, **kwargs)
+        # Note: Batch norm parameters (center/scale) are enabled by default in PyTorch unlike the TF wrapper
+        self.bn = nn.BatchNorm3d(out_channels)
+        # Using inplace ReLU can save memory
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x):
+        return self.relu(self.bn(self.conv(x)))
+
+class DeconvBnReLU3D(nn.Module):
+    """Basic ConvTranspose3D + BatchNorm3D + ReLU block."""
+    def __init__(self, in_channels, out_channels, kernel_size=3, stride=2, pad=1, output_pad=1, **kwargs):
+        super(DeconvBnReLU3D, self).__init__()
+        self.conv = nn.ConvTranspose3d(in_channels, out_channels, kernel_size=kernel_size,
+                                       stride=stride, padding=pad, output_padding=output_pad,
+                                       bias=False, **kwargs)
+        self.bn = nn.BatchNorm3d(out_channels)
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x):
+        return self.relu(self.bn(self.conv(x)))
+
+
+class CostRegularizer(nn.Module):
+    """
+    Network for regularizing the 3D cost volume using a 3D U-Net architecture.
+
+    Takes an input cost volume of shape (B, 32, D, H, W) and outputs a
+    regularized volume of shape (B, 1, D, H, W) representing logits before
+    softmax probability normalization.
+    """
+    def __init__(self, in_channels=32):
+        super(CostRegularizer, self).__init__()
+        print('Cost Regularizer: 3D UNet with 4 scales and 2 convs per scale.')
+        print(f'Input channels: {in_channels}')
+
+        # Initial convolution block reducing channels from 32 to 8
+        # Scale 0
+        self.conv0_0 = ConvBnReLU3D(in_channels, 8, kernel_size=3, stride=1, pad=1)
+        self.conv0_1 = ConvBnReLU3D(8, 8, kernel_size=3, stride=1, pad=1)
+
+        # Encoder Path
+        # Scale 1
+        self.conv1_0 = ConvBnReLU3D(8, 16, kernel_size=3, stride=2, pad=1)
+        self.conv1_1 = ConvBnReLU3D(16, 16, kernel_size=3, stride=1, pad=1)
+
+        # Scale 2
+        self.conv2_0 = ConvBnReLU3D(16, 32, kernel_size=3, stride=2, pad=1)
+        self.conv2_1 = ConvBnReLU3D(32, 32, kernel_size=3, stride=1, pad=1)
+
+        # Scale 3 (Bottleneck)
+        self.conv3_0 = ConvBnReLU3D(32, 64, kernel_size=3, stride=2, pad=1)
+        self.conv3_1 = ConvBnReLU3D(64, 64, kernel_size=3, stride=1, pad=1)
+
+        # Decoder Path
+        # Scale 2
+        self.deconv2 = DeconvBnReLU3D(64, 32, kernel_size=3, stride=2, pad=1, output_pad=1)
+        # After adding skip connection
+        self.deconv2_1 = ConvBnReLU3D(32, 32, kernel_size=3, stride=1, pad=1)
+
+        # Scale 1
+        self.deconv1 = DeconvBnReLU3D(32, 16, kernel_size=3, stride=2, pad=1, output_pad=1)
+        # After adding skip connection
+        self.deconv1_1 = ConvBnReLU3D(16, 16, kernel_size=3, stride=1, pad=1)
+
+        # Scale 0
+        self.deconv0 = DeconvBnReLU3D(16, 8, kernel_size=3, stride=2, pad=1, output_pad=1)
+        # After adding skip connection
+        self.deconv0_1 = ConvBnReLU3D(8, 8, kernel_size=3, stride=1, pad=1)
+
+        # Final 1x1x1 convolution to get 1 channel output (logits)
+        self.final_conv = nn.Conv3d(8, 1, kernel_size=3, stride=1, padding=1, bias=False)
+
+
+    def forward(self, x):
+        """
+        Args:
+            x: Input cost volume, shape (B, C, D, H, W). C=32 typically.
+        Returns:
+            Output volume, shape (B, 1, D, H, W). Represents logits before softmax.
+        """
+        # Encoder
+        conv0_0_out = self.conv0_0(x)
+        conv0_1_out = self.conv0_1(conv0_0_out) # Skip connection 0: (B, 8, D, H, W)
+
+        conv1_0_out = self.conv1_0(conv0_1_out)
+        conv1_1_out = self.conv1_1(conv1_0_out) # Skip connection 1: (B, 16, D, H/2, W/2)
+
+        conv2_0_out = self.conv2_0(conv1_1_out)
+        conv2_1_out = self.conv2_1(conv2_0_out) # Skip connection 2: (B, 32, D, H/4, W/4)
+
+        conv3_0_out = self.conv3_0(conv2_1_out)
+        conv3_1_out = self.conv3_1(conv3_0_out) # Bottleneck: (B, 64, D, H/8, W/8)
+
+        # Decoder
+        deconv2_out = self.deconv2(conv3_1_out) # Upsampled from bottleneck: (B, 32, D, H/4, W_deconv2)
+        # Crop deconv2_out to match conv2_1_out spatial size before adding skip connection
+        cropped_deconv2 = self._crop_like(deconv2_out, conv2_1_out)
+        add2 = cropped_deconv2 + conv2_1_out
+        deconv2_1_out = self.deconv2_1(add2)
+
+        deconv1_out = self.deconv1(deconv2_1_out) # Upsampled from scale 2: (B, 16, D, H/2, W_deconv1)
+        # Crop deconv1_out to match conv1_1_out spatial size before adding skip connection
+        cropped_deconv1 = self._crop_like(deconv1_out, conv1_1_out)
+        add1 = cropped_deconv1 + conv1_1_out
+        deconv1_1_out = self.deconv1_1(add1)
+
+        deconv0_out = self.deconv0(deconv1_1_out) # Upsampled from scale 1: (B, 8, D, H, W_deconv0)
+        # Crop deconv0_out to match conv0_1_out spatial size before adding skip connection
+        cropped_deconv0 = self._crop_like(deconv0_out, conv0_1_out)
+        add0 = cropped_deconv0 + conv0_1_out
+        deconv0_1_out = self.deconv0_1(add0)
+
+        # Final convolution
+        out_logits = self.final_conv(deconv0_1_out)
+
+        return out_logits
+    
+    def _crop_like(self, tensor_to_crop, target_tensor):
+        """Center crops tensor_to_crop to match target_tensor's spatial dims."""
+        target_shape = target_tensor.shape[2:] # D, H, W
+        current_shape = tensor_to_crop.shape[2:] # D, H, W
+
+        # If shapes already match, return original tensor
+        if target_shape == current_shape:
+            return tensor_to_crop
+
+        # Calculate cropping amounts (center crop)
+        diff_d = current_shape[0] - target_shape[0]
+        diff_h = current_shape[1] - target_shape[1]
+        diff_w = current_shape[2] - target_shape[2]
+
+        # Ensure we are not trying to pad (crop amount should be >= 0)
+        if diff_d < 0 or diff_h < 0 or diff_w < 0:
+             raise ValueError("Target shape must be smaller or equal for cropping.")
+
+        crop_d_start = diff_d // 2
+        crop_d_end = crop_d_start + target_shape[0]
+        crop_h_start = diff_h // 2
+        crop_h_end = crop_h_start + target_shape[1]
+        crop_w_start = diff_w // 2
+        crop_w_end = crop_w_start + target_shape[2]
+
+        return tensor_to_crop[:, :, crop_d_start:crop_d_end, crop_h_start:crop_h_end, crop_w_start:crop_w_end]
+
+
+# Example Usage (for testing the module)
+if __name__ == '__main__':
+    # Assume input Batch=2, Depth=48, Height=64, Width=80
+    B, D, H, W = 2, 48, 64, 80
+    C_in = 32 # Input channels specified by MVSNet feature extraction
+    C_out = 1 # Output channels (probability logits)
+
+    # Create dummy input tensor
+    # PyTorch uses (B, C, D, H, W) format for Conv3D
+    dummy_cost_volume = torch.randn(B, C_in, D, H, W)
+
+    # Instantiate the network
+    cost_regularizer = CostRegularizer(in_channels=C_in)
+
+    # Pass the dummy data through the network
+    output_volume = cost_regularizer(dummy_cost_volume)
+
+    # Check output shape
+    print(f"Input shape: {dummy_cost_volume.shape}")
+    print(f"Output shape: {output_volume.shape}")
+
+    # Verify the output shape matches expectation (B, C_out, D, H, W)
+    assert output_volume.shape == (B, C_out, D, H, W)
+
+    print("CostRegularizer module created and test forward pass successful!")
+
+    # You would typically apply Softmax after this outside the module:
+    # probability_volume = F.softmax(output_volume, dim=2) # Softmax along depth (D) dimension
+    # print(f"Shape after Softmax: {probability_volume.shape}")

--- a/tests/test_cost_regularisation.py
+++ b/tests/test_cost_regularisation.py
@@ -1,0 +1,145 @@
+# tests/test_cost_regularization.py
+
+import unittest
+import torch
+import sys
+import os
+
+from models.cost_regularizer import CostRegularizer
+
+
+class TestCostRegularizer(unittest.TestCase):
+
+    def test_initialization(self):
+        """Test if the model initializes without errors."""
+        try:
+            model = CostRegularizer(in_channels=32)
+            self.assertIsInstance(model, CostRegularizer)
+        except Exception as e:
+            self.fail(f"CostRegularizer initialization failed with exception: {e}")
+
+    def test_forward_pass_shape_cpu(self):
+        """Test the forward pass and output shape on CPU."""
+        B, C_in, D, H, W = 2, 32, 16, 32, 40 # Example dimensions
+        C_out = 1
+        expected_shape = (B, C_out, D, H, W)
+
+        model = CostRegularizer(in_channels=C_in)
+        dummy_input = torch.randn(B, C_in, D, H, W)
+
+        # Set model to evaluation mode for consistent behavior (e.g., BatchNorm)
+        model.eval()
+        with torch.no_grad(): # No need to track gradients for shape testing
+            output = model(dummy_input)
+
+        self.assertEqual(output.shape, expected_shape,
+                         f"Output shape mismatch. Expected {expected_shape}, got {output.shape}")
+
+    def test_forward_pass_various_shapes(self):
+        """Test forward pass with different valid input shapes."""
+        shapes_to_test = [
+            (1, 32, 8, 16, 16),   # Smallest
+            (4, 32, 32, 64, 64),  # Larger batch, typical size
+            (2, 32, 24, 48, 56)   # Odd dimensions
+        ]
+        C_out = 1
+        model = CostRegularizer(in_channels=32)
+        model.eval()
+
+        for shape in shapes_to_test:
+            B, C_in, D, H, W = shape
+            expected_shape = (B, C_out, D, H, W)
+            dummy_input = torch.randn(*shape)
+            with torch.no_grad():
+                output = model(dummy_input)
+
+            self.assertEqual(output.shape, expected_shape,
+                             f"Output shape mismatch for input {shape}. Expected {expected_shape}, got {output.shape}")
+
+
+    def test_gradient_flow(self):
+        """Test if gradients can flow back through the network."""
+        B, C_in, D, H, W = 1, 32, 8, 16, 20 # Smaller size for faster test
+        C_out = 1
+
+        model = CostRegularizer(in_channels=C_in)
+        # Ensure model is in training mode
+        model.train()
+
+        # Create input that requires gradients
+        dummy_input = torch.randn(B, C_in, D, H, W, requires_grad=True)
+        # Create a dummy target with the same shape as the output
+        dummy_target = torch.randn(B, C_out, D, H, W)
+
+        # Forward pass
+        output = model(dummy_input)
+
+        # Calculate a simple loss
+        loss = torch.nn.functional.mse_loss(output, dummy_target)
+
+        # Backward pass
+        try:
+            loss.backward()
+        except Exception as e:
+            self.fail(f"loss.backward() failed with exception: {e}")
+
+        # Check if any parameter has received gradients
+        grad_found = False
+        for param in model.parameters():
+            if param.grad is not None:
+                # Check if gradient is not all zeros (might happen in edge cases, but unlikely here)
+                if torch.abs(param.grad).sum() > 1e-8:
+                     grad_found = True
+                     break
+        self.assertTrue(grad_found, "No gradients found in model parameters after backward pass.")
+        self.assertIsNotNone(dummy_input.grad, "Input tensor did not receive gradients.")
+
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    def test_forward_pass_shape_gpu(self):
+        """Test the forward pass and output shape on GPU if available."""
+        B, C_in, D, H, W = 2, 32, 16, 32, 40
+        C_out = 1
+        expected_shape = (B, C_out, D, H, W)
+        device = torch.device("cuda")
+
+        model = CostRegularizer(in_channels=C_in).to(device)
+        dummy_input = torch.randn(B, C_in, D, H, W, device=device)
+
+        model.eval()
+        with torch.no_grad():
+            output = model(dummy_input)
+
+        self.assertEqual(output.shape, expected_shape,
+                         f"Output shape mismatch on GPU. Expected {expected_shape}, got {output.shape}")
+        self.assertEqual(output.device.type, "cuda", "Output tensor is not on CUDA device.")
+
+    def test_training_mode_behavior(self):
+        """Check if BatchNorm layers are in training mode by default."""
+        model = CostRegularizer(in_channels=32)
+        model.train() # Explicitly set to train (should be default)
+
+        # Check a BatchNorm layer (e.g., the first one)
+        # Accessing internal layers like this is slightly fragile but common in tests
+        self.assertTrue(model.conv0_0.bn.training, "BatchNorm layer is not in training mode after model.train()")
+
+    def test_eval_mode_behavior(self):
+        """Check if BatchNorm layers switch to eval mode."""
+        model = CostRegularizer(in_channels=32)
+        model.eval()
+
+        # Check a BatchNorm layer
+        self.assertFalse(model.conv0_0.bn.training, "BatchNorm layer is not in eval mode after model.eval()")
+        # Also check forward pass runs in eval mode
+        B, C_in, D, H, W = 1, 32, 8, 16, 16
+        dummy_input = torch.randn(B, C_in, D, H, W)
+        try:
+            with torch.no_grad():
+                model(dummy_input)
+        except Exception as e:
+             self.fail(f"Forward pass failed in eval mode: {e}")
+
+
+# This allows running the tests from the command line
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a new `CostRegularizer` module, which implements a 3D U-Net architecture for cost volume regularization in multi-view stereo (MVS) tasks. Additionally, it includes comprehensive unit tests to validate the functionality, robustness, and behavior of the module under various conditions.

### New Module Implementation:
* Added the `CostRegularizer` class in `models/cost_regularizer.py`, which processes 3D cost volumes using a U-Net-like architecture with skip connections and 3D convolutional layers. It outputs logits for softmax probability normalization. The implementation includes helper classes `ConvBnReLU3D` and `DeconvBnReLU3D` for modular 3D convolutional blocks.

### Unit Tests:
* Created a new test suite in `tests/test_cost_regularization.py` to validate the `CostRegularizer` module. Tests include:
  - Model initialization and forward pass shape validation on both CPU and GPU.
  - Gradient flow verification to ensure proper backpropagation.
  - Behavior testing for training and evaluation modes, particularly for BatchNorm layers.