### PR TITLE
Feat/add self attn layer

### DIFF
--- a/models/layers/self_attention.py
+++ b/models/layers/self_attention.py
@@ -1,0 +1,65 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class SelfAttentionLayer(nn.Module):
+    """
+    Applies self-attention across views and returns the output for the reference image.
+    
+    This layer takes a tensor representing features from multiple views
+    (e.g., from an MVSNet setup) and applies self-attention across those views.
+    It then returns the output corresponding to the reference image only.
+    
+    Input shape: (N, T, D, C, H, W) where N is batch size, T is number of views, 
+    D is depth, C is channels, H and W are spatial dimensions.
+    Output shape: (N, D, C, H, W)
+    """
+    def __init__(self):
+        super(SelfAttentionLayer, self).__init__()
+        self.query_conv = nn.Conv3d(in_channels=1, out_channels=1, kernel_size=1)
+        self.key_conv = nn.Conv3d(in_channels=1, out_channels=1, kernel_size=1)
+        self.value_conv = nn.Identity()  # Identity to preserve the original values
+        self.gamma = nn.Parameter(torch.zeros(1))  # Learnable scaling parameter
+        
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass of the SelfAttentionLayer.
+
+        Args:
+            x (torch.Tensor): Input tensor of shape (N, T, D, C, H, W).
+
+        Returns:
+            torch.Tensor: Output tensor of shape (N, D, C, H, W) representing the 
+                         attended features for the reference image.
+        """
+        N, T, D, C, H, W = x.shape
+        
+        # Reference image is at index 0
+        reference_img = x[:, 0]  # Shape: (N, D, C, H, W)
+        
+        # Reshape for attention computation
+        # We'll treat each channel separately for simplicity
+        batch_size = N * D * C
+        
+        # Reshape to (N*D*C, T, H*W)
+        x_reshaped = x.permute(0, 2, 3, 1, 4, 5).reshape(batch_size, T, H*W)
+        
+        # Create query from reference image
+        # Shape: (N*D*C, 1, H*W)
+        query = x_reshaped[:, 0:1, :]
+        
+        # Compute attention weights (scaled dot product attention)
+        # Shape: (N*D*C, 1, T)
+        attention = torch.bmm(query, x_reshaped.transpose(1, 2))
+        attention = F.softmax(attention / (H*W)**0.5, dim=2)
+        
+        # Apply attention to values
+        # Shape: (N*D*C, 1, H*W)
+        out = torch.bmm(attention, x_reshaped)
+        
+        # Reshape back to original dimensions but without the T dimension
+        # Shape: (N, D, C, H, W)
+        out = out.view(N, D, C, H, W)
+        
+        # Apply learnable scaling and residual connection for the reference image
+        return self.gamma * out + reference_img

--- a/models/mvsnet.py
+++ b/models/mvsnet.py
@@ -3,6 +3,7 @@ from .sublayers import CNNBlock
 from .layers.feature_extraction import ImageEncoder
 from .layers.homografy import Homography
 from .layers.variance import VarianceLayer
+from .layers.self_attention import SelfAttentionLayer
 from .layers.cost_regularizer import CostRegularizer
 from .layers.soft_argmin import SoftArgmin
 from .layers.refinement import Refine
@@ -13,7 +14,8 @@ class MVSNet(torch.nn.Module):
       self.depths = torch.arange(0, 1.0001, 1 / n_depths)
       self.feature_extractor = ImageEncoder()
       self.homography = Homography(depths=self.depths)
-      self.variance = VarianceLayer()
+      # self.variance = VarianceLayer()
+      self.variance = SelfAttentionLayer()
       self.cost_regularizer = CostRegularizer(in_channels=32)
       self.soft_argmin = SoftArgmin()
       self.refinement = Refine()

--- a/tests/test_self_attention.py
+++ b/tests/test_self_attention.py
@@ -1,0 +1,90 @@
+# tests/test_self_attention.py
+import unittest
+import torch
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+from models.layers.self_attention import SelfAttentionLayer
+
+class TestSelfAttentionLayer(unittest.TestCase):
+    
+    def test_output_shape(self):
+        """Tests if the output shape is correct."""
+        N, T, D, C, H, W = 4, 3, 8, 16, 32, 32
+        input_tensor = torch.randn(N, T, D, C, H, W)
+        attention_layer = SelfAttentionLayer()
+        output_tensor = attention_layer(input_tensor)
+        
+        # Output should be (N, D, C, H, W) - without the T dimension
+        self.assertEqual(output_tensor.shape, (N, D, C, H, W))
+    
+    def test_reference_image_preservation(self):
+        """Tests if the reference image is preserved when gamma is zero."""
+        N, T, D, C, H, W = 2, 3, 4, 8, 16, 16
+        input_tensor = torch.randn(N, T, D, C, H, W)
+        
+        # Store the reference image
+        reference_img = input_tensor[:, 0].clone()
+        
+        # Create layer with gamma initialized to zero (default)
+        attention_layer = SelfAttentionLayer()
+        # Ensure gamma is zero
+        attention_layer.gamma.data.zero_()
+        
+        output_tensor = attention_layer(input_tensor)
+        
+        # When gamma is zero, output should equal reference image
+        self.assertTrue(torch.allclose(output_tensor, reference_img))
+    
+    def test_attention_mechanism(self):
+        """Tests the attention mechanism with a simple known case."""
+        N, T, D, C, H, W = 1, 2, 1, 1, 2, 2
+        
+        # Create a simple input where the first view is the reference image
+        # and the second view has higher values
+        view1 = torch.ones((N, D, C, H, W))  # Reference image with all 1s
+        view2 = torch.full((N, D, C, H, W), 2.0)  # Second view with all 2s
+        input_tensor = torch.stack((view1, view2), dim=1)  # Shape (N, T, D, C, H, W)
+        
+        attention_layer = SelfAttentionLayer()
+        # Set gamma to 1 for full attention effect
+        attention_layer.gamma.data.fill_(1.0)
+        
+        output_tensor = attention_layer(input_tensor)
+        
+        # With attention active and gamma=1, output should be influenced by view2
+        # But still have residual connection to view1
+        # The exact value depends on the attention implementation, but should be > 1
+        self.assertTrue(torch.all(output_tensor > view1))
+        self.assertEqual(output_tensor.shape, (N, D, C, H, W))
+    
+    def test_with_single_view(self):
+        """Tests behavior when only the reference view is provided."""
+        N, D, C, H, W = 2, 4, 8, 16, 16
+        # Only one view (the reference)
+        input_tensor = torch.randn(N, 1, D, C, H, W)
+        reference_img = input_tensor[:, 0].clone()
+        
+        attention_layer = SelfAttentionLayer()
+        output_tensor = attention_layer(input_tensor)
+        
+        # With only one view, output should be equal to input reference
+        self.assertTrue(torch.allclose(output_tensor, reference_img))
+        self.assertEqual(output_tensor.shape, (N, D, C, H, W))
+    
+    def test_different_dimensions(self):
+        """Tests with different valid dimensions."""
+        N, T, D, C, H, W = 5, 4, 16, 32, 24, 24
+        input_tensor = torch.randn(N, T, D, C, H, W)
+        attention_layer = SelfAttentionLayer()
+        output_tensor = attention_layer(input_tensor)
+        
+        self.assertEqual(output_tensor.shape, (N, D, C, H, W))
+        # Check if attention calculation runs without error
+        self.assertTrue(output_tensor is not None)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a new `SelfAttentionLayer` to enhance the attention mechanism in the MVSNet model, replacing the existing `VarianceLayer`. It also includes comprehensive unit tests for the new layer to ensure its correctness and robustness.

### New Feature: Self-Attention Layer

* **`models/layers/self_attention.py`**: Added the `SelfAttentionLayer` class, which applies self-attention across multiple views and outputs the attended features for the reference image. This implementation includes a learnable scaling parameter (`gamma`) and residual connection to preserve the reference image.

### Integration into MVSNet

* **`models/mvsnet.py`**:
  * Imported the `SelfAttentionLayer` to replace the `VarianceLayer`.
  * Updated the `__init__` method to instantiate `SelfAttentionLayer` instead of `VarianceLayer`.

### Testing and Validation

* **`tests/test_self_attention.py`**: Added a new test suite for `SelfAttentionLayer` with the following tests:
  * Verifies the output shape matches expectations. 
  * Ensures the reference image is preserved when `gamma` is set to zero.
  * Validates the attention mechanism with a controlled input case.
  * Tests behavior with a single view and varying input dimensions.